### PR TITLE
Add MySQL setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Or using `msbuild`/`xbuild` if `dotnet` is unavailable.
 After building, execute the compiled `ProjectSensors.exe` from the `bin` directory.
 
 The game records sessions to a MySQL database using the connection string you provide when creating the DAL classes.
+
+## Database Setup
+
+Run the `mysql_setup.sql` script in your MySQL server (for example using phpMyAdmin) to create the default `game` database and the required `players` and `game_history` tables.

--- a/mysql_setup.sql
+++ b/mysql_setup.sql
@@ -1,0 +1,24 @@
+-- SQL script to create the required MySQL database and tables for ProjectSensors
+
+-- Create database if it doesn't exist
+CREATE DATABASE IF NOT EXISTS game CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE game;
+
+-- Table for storing player progression
+CREATE TABLE IF NOT EXISTS players (
+    username VARCHAR(100) NOT NULL,
+    highest_rank_unlocked INT NOT NULL,
+    PRIMARY KEY (username)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table for recording game history
+CREATE TABLE IF NOT EXISTS game_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    agent_type VARCHAR(100) NOT NULL,
+    weakness_combo VARCHAR(255) NOT NULL,
+    used_sensors VARCHAR(255) NOT NULL,
+    correct_sensors VARCHAR(255) NOT NULL,
+    turns_taken INT NOT NULL,
+    victory TINYINT(1) NOT NULL,
+    timestamp DATETIME NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- create `mysql_setup.sql` with schema for `game` database
- document running the setup script in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851227c1e28832da798a8887c361f31