### PR TITLE
Fix sensor logic and show game outcome

### DIFF
--- a/ProjectSensors/Entities/AbstractClasses/IranianAgent.cs
+++ b/ProjectSensors/Entities/AbstractClasses/IranianAgent.cs
@@ -34,19 +34,19 @@ namespace ProjectSensors.Entities.AbstractClasses
 
         public virtual int Activate()
         {
-            int correct = 0;
+            var matchedTypes = new HashSet<SensorType>();
             foreach (Sensor sensor in AttachedSensors)
             {
                 if (sensor.Activate(WeaknessCombination))
-                    correct++;
+                    matchedTypes.Add(sensor.Type);
             }
 
-            if (correct == WeaknessCombination.Count)
+            if (matchedTypes.Count == WeaknessCombination.Count)
                 IsExposed = true;
 
             TurnCounter++;
             ActivateCounter++;
-            return correct;
+            return matchedTypes.Count;
         }
 
         public bool CheckIfExposed()

--- a/ProjectSensors/Managers/InvestigationManager.cs
+++ b/ProjectSensors/Managers/InvestigationManager.cs
@@ -69,6 +69,9 @@ namespace ProjectSensors.Managers
                                 true,
                                 currentAgent.GetWeaknesses()));
 
+                            Console.WriteLine("\nPress any key to continue...");
+                            Console.ReadKey();
+
                             gameRunning = false;
                         }
                         else if (attempts >= maxAttemptsForAgent)
@@ -84,6 +87,11 @@ namespace ProjectSensors.Managers
                                 attempts,
                                 false,
                                 currentAgent.GetWeaknesses()));
+
+                            Console.WriteLine("\nPress any key to continue...");
+                            Console.ReadKey();
+
+                            gameRunning = false;
                         }
                     }
                     catch (Exception ex)
@@ -94,10 +102,7 @@ namespace ProjectSensors.Managers
                     }
                 }
 
-                if (!currentAgent.CheckIfExposed() || attempts >= maxAttemptsForAgent)
-                {
-                     GameHistory.Instance.DisplayHistory();
-                }
+                GameHistory.Instance.DisplayHistory();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- fix sensor activation logic to check unique sensor matches
- prompt on success/failure before clearing screen
- always show game history after each session

## Testing
- `xbuild ProjectSensors.sln` *(fails: MySql.Data missing)*

------
https://chatgpt.com/codex/tasks/task_e_68512b48e81c832dbb3c9f1bcf677255