### PR TITLE
Fix session history and turn logic

### DIFF
--- a/ProjectSensors/Managers/InvestigationManager.cs
+++ b/ProjectSensors/Managers/InvestigationManager.cs
@@ -35,6 +35,7 @@ namespace ProjectSensors.Managers
                 while (gameRunning && attempts < maxAttemptsForAgent)
                 {
                     attempts++;
+                    currentAgent.OnTurnStart();
                     Console.WriteLine($"\nAttempt {attempts} of {maxAttemptsForAgent}");
                     Console.WriteLine("----------------------------------------");
 
@@ -103,8 +104,6 @@ namespace ProjectSensors.Managers
                         attempts--; 
                     }
                 }
-
-                GameHistory.Instance.DisplayHistory(PlayerSession.Username);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- show agent turn-based actions by calling `OnTurnStart`
- stop auto-displaying history after each investigation

## Testing
- `xbuild ProjectSensors.sln /p:Configuration=Release` *(fails: `MySql` references missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851367e2d20832d9054e96b699649d1