### PR TITLE
Add login/logout and admin history support

### DIFF
--- a/ProjectSensors/Managers/GameHistory.cs
+++ b/ProjectSensors/Managers/GameHistory.cs
@@ -54,7 +54,7 @@ namespace ProjectSensors.Managers
             }
         }
 
-        public void DisplayHistory(string username)
+        public void DisplayHistory(string username = null)
         {
             Console.Clear();
             Console.WriteLine("=== GAME HISTORY ===");
@@ -62,7 +62,14 @@ namespace ProjectSensors.Managers
             List<GameHistoryEntry> entries = new List<GameHistoryEntry>();
             try
             {
-                entries = _historyDal.GetByUser(username);
+                if (string.IsNullOrWhiteSpace(username))
+                {
+                    entries = _historyDal.GetAll();
+                }
+                else
+                {
+                    entries = _historyDal.GetByUser(username);
+                }
             }
             catch (Exception ex)
             {

--- a/ProjectSensors/Program.cs
+++ b/ProjectSensors/Program.cs
@@ -14,32 +14,42 @@ namespace ProjectSensors
         {
             try
             {
-                string user;
-                do
-                {
-                    Console.Write("Enter username: ");
-                    user = Console.ReadLine();
-                    if (string.IsNullOrWhiteSpace(user))
-                    {
-                        Console.WriteLine("Username cannot be empty. Please try again.");
-                    }
-                } while (string.IsNullOrWhiteSpace(user));
-
-                PlayerSession.Login(user);
-
                 var conn = Environment.GetEnvironmentVariable("GAME_DB_CONN") ??
                             "server=localhost;user id=root;password=;database=game";
                 var playerDal = new PlayerDal(conn);
-                try
-                {
-                    playerDal.EnsurePlayerExists(user);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Error in EnsurePlayerExists: {ex.Message}");
-                }
 
-                MenuManager.StartApplicationLoop();
+                bool exitProgram = false;
+                while (!exitProgram)
+                {
+                    string user;
+                    do
+                    {
+                        Console.Write("Enter username: ");
+                        user = Console.ReadLine();
+                        if (string.IsNullOrWhiteSpace(user))
+                        {
+                            Console.WriteLine("Username cannot be empty. Please try again.");
+                        }
+                    } while (string.IsNullOrWhiteSpace(user));
+
+                    PlayerSession.Login(user);
+
+                    try
+                    {
+                        playerDal.EnsurePlayerExists(user);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Error in EnsurePlayerExists: {ex.Message}");
+                    }
+
+                    bool logout = MenuManager.StartApplicationLoop();
+                    if (!logout)
+                    {
+                        exitProgram = true;
+                    }
+                    PlayerSession.Logout();
+                }
             }
             catch (Exception ex)
             {

--- a/ProjectSensors/Tools/PlayerDal.cs
+++ b/ProjectSensors/Tools/PlayerDal.cs
@@ -32,5 +32,33 @@ namespace ProjectSensors.Tools
                 Console.WriteLine($"Error in PlayerDal.EnsurePlayerExists: {ex.Message}");
             }
         }
+
+        public System.Collections.Generic.List<string> GetAllUsernames()
+        {
+            var list = new System.Collections.Generic.List<string>();
+            try
+            {
+                using (var conn = new MySqlConnection(_connectionString))
+                {
+                    conn.Open();
+                    using (var cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT username FROM players";
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                list.Add(reader.GetString("username"));
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in PlayerDal.GetAllUsernames: {ex.Message}");
+            }
+            return list;
+        }
     }
 }

--- a/ProjectSensors/Tools/PlayerSession.cs
+++ b/ProjectSensors/Tools/PlayerSession.cs
@@ -3,10 +3,17 @@ namespace ProjectSensors.Tools
     public static class PlayerSession
     {
         public static string Username { get; private set; }
+        public static bool IsAdmin =>
+            !string.IsNullOrEmpty(Username) && Username.Equals("admin", System.StringComparison.OrdinalIgnoreCase);
 
         public static void Login(string username)
         {
             Username = username;
+        }
+
+        public static void Logout()
+        {
+            Username = null;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Run the `mysql_setup.sql` script in your MySQL server (for example using phpMyAd
 
 If you upgraded from an older version and encounter errors like `Unknown column 'username'` or `Unknown column 'score'`, your existing `game_history` table is missing these fields. Run the provided `mysql_upgrade.sql` script to add the required columns and create the foreign key linking `game_history.username` to the `players` table.
 
-When starting the application you will be prompted for a username. History and scores are tracked separately for each player.
+When starting the application you will be prompted for a username. After logging in you can play, view your history or log out to switch users. A special user named `admin` can view the history of all players.


### PR DESCRIPTION
## Summary
- add admin check and logout functionality to `PlayerSession`
- support listing players in `PlayerDal`
- allow viewing all history or specific player history in `MenuManager`
- loop login/logout flow in `Program`
- document admin user and logout in README

## Testing
- `dotnet build ProjectSensors.sln -c Release` *(fails: command not found)*
- `msbuild ProjectSensors.sln /t:Build /p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685140465fec832d93513658d4326d59