### PR TITLE
Fix unused player rank column

### DIFF
--- a/ProjectSensors/Managers/InvestigationManager.cs
+++ b/ProjectSensors/Managers/InvestigationManager.cs
@@ -71,6 +71,18 @@ namespace ProjectSensors.Managers
                                 true,
                                 currentAgent.GetWeaknesses()));
 
+                            try
+                            {
+                                var conn = Environment.GetEnvironmentVariable("GAME_DB_CONN") ??
+                                            "server=localhost;user id=root;password=;database=game";
+                                var statsDal = new AgentDal(conn);
+                                statsDal.UpdatePlayerStats(PlayerSession.Username, (int)currentAgent.Rank);
+                            }
+                            catch (Exception ex)
+                            {
+                                Console.WriteLine($"Error updating player stats: {ex.Message}");
+                            }
+
                             Console.WriteLine("\nPress any key to continue...");
                             Console.ReadKey();
 

--- a/ProjectSensors/Tools/AgentDal.cs
+++ b/ProjectSensors/Tools/AgentDal.cs
@@ -22,7 +22,7 @@ namespace ProjectSensors.Tools
                     using (var cmd = conn.CreateCommand())
                     {
                         cmd.CommandText = "INSERT INTO players(username, highest_rank_unlocked) VALUES(@user, @rank) " +
-                                         "ON DUPLICATE KEY UPDATE highest_rank_unlocked=@rank";
+                                         "ON DUPLICATE KEY UPDATE highest_rank_unlocked = GREATEST(highest_rank_unlocked, @rank)";
                         cmd.Parameters.AddWithValue("@user", username);
                         cmd.Parameters.AddWithValue("@rank", highestRank);
                         cmd.ExecuteNonQuery();

--- a/ProjectSensors/Tools/PlayerDal.cs
+++ b/ProjectSensors/Tools/PlayerDal.cs
@@ -60,5 +60,29 @@ namespace ProjectSensors.Tools
             }
             return list;
         }
+
+        public int GetHighestRank(string username)
+        {
+            try
+            {
+                using (var conn = new MySqlConnection(_connectionString))
+                {
+                    conn.Open();
+                    using (var cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT highest_rank_unlocked FROM players WHERE username=@user";
+                        cmd.Parameters.AddWithValue("@user", username);
+                        var result = cmd.ExecuteScalar();
+                        if (result != null && int.TryParse(result.ToString(), out int rank))
+                            return rank;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in PlayerDal.GetHighestRank: {ex.Message}");
+            }
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update player stats SQL to only raise highest rank
- expose highest rank via `PlayerDal`
- save highest rank after successful interrogation

## Testing
- `dotnet build ProjectSensors.sln` *(fails: command not found)*
- `msbuild ProjectSensors.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685152e8efc4832d89960f8b8dc49867