### PR TITLE
Fix sensor durability handling and ensure winnable logic

### DIFF
--- a/ProjectSensors/Entities/AbstractClasses/IBreakableSensor.cs
+++ b/ProjectSensors/Entities/AbstractClasses/IBreakableSensor.cs
@@ -1,0 +1,8 @@
+
+namespace ProjectSensors.Entities.AbstractClasses
+{
+    public interface IBreakableSensor
+    {
+        bool IsBroken { get; }
+    }
+}

--- a/ProjectSensors/Entities/AbstractClasses/IranianAgent.cs
+++ b/ProjectSensors/Entities/AbstractClasses/IranianAgent.cs
@@ -39,13 +39,21 @@ namespace ProjectSensors.Entities.AbstractClasses
         public virtual int Activate()
         {
             var matchedTypes = new HashSet<SensorType>();
-            foreach (Sensor sensor in AttachedSensors)
+            for (int i = AttachedSensors.Count - 1; i >= 0; i--)
             {
+                var sensor = AttachedSensors[i];
                 if (sensor.Activate(WeaknessCombination))
                     matchedTypes.Add(sensor.Type);
+
+                if (sensor is IBreakableSensor br && br.IsBroken)
+                {
+                    AttachedSensors.RemoveAt(i);
+                    Console.WriteLine($"{sensor.Name} was removed after breaking.");
+                }
             }
 
-            double ratio = (double)matchedTypes.Count / WeaknessCombination.Count;
+            int required = new HashSet<SensorType>(WeaknessCombination).Count;
+            double ratio = (double)matchedTypes.Count / required;
             if (ratio >= 1)
                 Mood = AgentMood.Panicked;
             else if (ratio >= 0.75)
@@ -76,7 +84,7 @@ namespace ProjectSensors.Entities.AbstractClasses
             Console.WriteLine($"Agent mood: {Mood}");
             Console.ForegroundColor = prev;
 
-            if (matchedTypes.Count == WeaknessCombination.Count)
+            if (matchedTypes.Count == required)
                 IsExposed = true;
 
             TurnCounter++;

--- a/ProjectSensors/Entities/Sensors/JammerSensor.cs
+++ b/ProjectSensors/Entities/Sensors/JammerSensor.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ProjectSensors.Entities.Sensors
 {
-    public class JammerSensor : Sensor
+    public class JammerSensor : Sensor, IBreakableSensor
     {
         private bool _used;
         private static readonly Random rnd = new Random();
@@ -27,5 +27,7 @@ namespace ProjectSensors.Entities.Sensors
             }
             return false; // jammer does not directly detect
         }
+
+        public bool IsBroken => _used;
     }
 }

--- a/ProjectSensors/Entities/Sensors/MotionSensor.cs
+++ b/ProjectSensors/Entities/Sensors/MotionSensor.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ProjectSensors.Entities.Sensors
 {
-    public class MotionSensor : Sensor
+    public class MotionSensor : Sensor, IBreakableSensor
     {
         private int usesLeft;
 
@@ -15,17 +15,18 @@ namespace ProjectSensors.Entities.Sensors
 
         public override bool Activate(List<SensorType> weaknesses)
         {
-            if (IsBroken())
+            if (IsBroken)
                 return false;
 
             usesLeft--;
+            if (IsBroken)
+            {
+                System.Console.WriteLine("Motion sensor broke!");
+            }
 
             return weaknesses.Contains(Type);
         }
 
-        public bool IsBroken()
-        {
-            return usesLeft <= 0;
-        }
+        public bool IsBroken => usesLeft <= 0;
     }
 }

--- a/ProjectSensors/Entities/Sensors/PulseSensor.cs
+++ b/ProjectSensors/Entities/Sensors/PulseSensor.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ProjectSensors.Entities.Sensors
 {
-    public class PulseSensor : Sensor
+    public class PulseSensor : Sensor, IBreakableSensor
     {
         private int usesLeft;
 
@@ -15,17 +15,18 @@ namespace ProjectSensors.Entities.Sensors
 
         public override bool Activate(List<SensorType> weaknesses)
         {
-            if (IsBroken())
+            if (IsBroken)
                 return false;
 
             usesLeft--;
+            if (IsBroken)
+            {
+                System.Console.WriteLine("Pulse sensor broke!");
+            }
 
             return weaknesses.Contains(Type);
         }
 
-        public bool IsBroken()
-        {
-            return usesLeft <= 0;
-        }
+        public bool IsBroken => usesLeft <= 0;
     }
 }

--- a/ProjectSensors/Factory/AgentFactory.cs
+++ b/ProjectSensors/Factory/AgentFactory.cs
@@ -45,24 +45,21 @@ namespace ProjectSensors.Factories
 
         public static List<SensorType> GetRandomWeaknesses(List<SensorType> pool, int count)
         {
-            if (count > pool.Count)
+            var result = new List<SensorType>();
+            if (pool.Count == 0 || count <= 0)
+                return result;
+
+            int attempts = 0;
+            while (result.Count < count && attempts < 100)
             {
-                count = pool.Count;
+                var type = pool[random.Next(pool.Count)];
+                int existing = result.Count(t => t == type);
+                if (existing < 3)
+                    result.Add(type);
+                attempts++;
             }
 
-            List<SensorType> shuffledPool = new List<SensorType>(pool);
-
-            int n = shuffledPool.Count;
-            while (n > 1)
-            {
-                n--;
-                int k = random.Next(n + 1);
-                SensorType value = shuffledPool[k];
-                shuffledPool[k] = shuffledPool[n];
-                shuffledPool[n] = value;
-            }
-
-            return shuffledPool.Take(count).ToList();
+            return result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `IBreakableSensor` interface
- implement breakable logic for Motion, Pulse and Jammer sensors
- remove broken sensors when agents activate them
- base exposure check on unique weakness types
- allow at most three identical weakness types when generating agents

## 